### PR TITLE
Problemas com CEP sem código GIA

### DIFF
--- a/ViaCEP.Tests/ZipCodeTests.cs
+++ b/ViaCEP.Tests/ZipCodeTests.cs
@@ -15,9 +15,9 @@ namespace ViaCEP.Tests
         {
             var result = ViaCEPClient.Search("03177010");
             Assert.NotNull(result);
-            Assert.Equal("Rua Doutor Jo�o Batista de Lacerda", result.Street);
+            Assert.Equal("Rua Doutor João Batista de Lacerda", result.Street);
             Assert.Equal("Quarta Parada", result.Neighborhood);
-            Assert.Equal("S�o Paulo", result.City);
+            Assert.Equal("São Paulo", result.City);
             Assert.Equal("SP", result.StateInitials);
         }
         

--- a/ViaCEP.Tests/ZipCodeTests.cs
+++ b/ViaCEP.Tests/ZipCodeTests.cs
@@ -15,10 +15,23 @@ namespace ViaCEP.Tests
         {
             var result = ViaCEPClient.Search("03177010");
             Assert.NotNull(result);
-            Assert.Equal("Rua Doutor João Batista de Lacerda", result.Street);
+            Assert.Equal("Rua Doutor Joï¿½o Batista de Lacerda", result.Street);
             Assert.Equal("Quarta Parada", result.Neighborhood);
-            Assert.Equal("São Paulo", result.City);
+            Assert.Equal("Sï¿½o Paulo", result.City);
             Assert.Equal("SP", result.StateInitials);
+        }
+        
+        
+        /// <summary>
+        /// Validates if the search by zip code don't throw a exception if the address doesn't have a gia code 
+        /// </summary>
+        /// <returns></returns>
+        [Fact]
+        public void ValidateSearchByZipCodeWithoutGiaCode()
+        {
+            var result = ViaCEPClient.Search("22795641");
+            Assert.NotNull(result);
+            Assert.Null(result.GIACode);
         }
     }
 }

--- a/ViaCEP/VIaCEPResult.cs
+++ b/ViaCEP/VIaCEPResult.cs
@@ -87,6 +87,6 @@
         /// The gia code.
         /// </value>
         [JsonProperty("gia")]
-        public Int32 GIACode { get; set; }
+        public Int32? GIACode { get; set; }
     }
 }


### PR DESCRIPTION
Oi Guilherme,

Estou usando a sua biblioteca no meu projeto e está acontecendo um problema quando faço busca de CEPs que não tem o GIACode, como por exemplo: 26525122 e 22795641. Quando eu faço a busca, o código tenta fazer a serialização do resultado para o modelo ViaCEPResult e como ele espera um inteiro e recebe uma string vazia, gera a seguinte exceção:

`      One or more errors occurred. (Error converting value {null} to type 'System.Int32'. Path 'gia', line 10, position 11.)
Newtonsoft.Json.JsonSerializationException: Error converting value {null} to type 'System.Int32'. Path 'gia', line 10, position 11. ---> System.InvalidCastException: Null object cannot be converted to a value type.
   at System.Convert.ChangeType(Object value, Type conversionType, IFormatProvider provider)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.EnsureType(JsonReader reader, Object value, CultureInfo culture, JsonContract contract, Type targetType)
   --- End of inner exception stack trace ---
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.EnsureType(JsonReader reader, Object value, CultureInfo culture, JsonContract contract, Type targetType)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.SetPropertyValue(JsonProperty property, JsonConverter propertyConverter, JsonContainerContract containerContract, JsonProperty containerProperty, JsonReader reader, Object target)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.PopulateObject(Object newObject, JsonReader reader, JsonObjectContract contract, JsonProperty member, String id)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateObject(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, JsonContainerContract containerContract, JsonProperty containerMember, Object existingValue)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.Deserialize(JsonReader reader, Type objectType, Boolean checkAdditionalContent)
   at Newtonsoft.Json.JsonSerializer.DeserializeInternal(JsonReader reader, Type objectType)
   at System.Net.Http.Formatting.BaseJsonMediaTypeFormatter.ReadFromStream(Type type, Stream readStream, Encoding effectiveEncoding, IFormatterLogger formatterLogger)
   at System.Net.Http.Formatting.BaseJsonMediaTypeFormatter.ReadFromStream(Type type, Stream readStream, HttpContent content, IFormatterLogger formatterLogger)
   at System.Net.Http.Formatting.BaseJsonMediaTypeFormatter.ReadFromStreamAsync(Type type, Stream readStream, HttpContent content, IFormatterLogger formatterLogger)
--- End of stack trace from previous location where exception was thrown ---
   at System.Net.Http.HttpContentExtensions.ReadAsAsyncCore[T](HttpContent content, Type type, IFormatterLogger formatterLogger, MediaTypeFormatter formatter, CancellationToken cancellationToken)
   at ViaCEP.ViaCEPClient.SearchAsync(String zipCode, CancellationToken token)`

Buscando um dos CEPs acima diretamente na API do ViaCep, você pode ver que ele não contém mesmo um GIACode: https://viacep.com.br/ws/22795641/json/

`{
cep: "22795-641",
logradouro: "Avenida Henfil",
complemento: "até 600/601",
bairro: "Recreio dos Bandeirantes",
localidade: "Rio de Janeiro",
uf: "RJ",
unidade: "",
ibge: "3304557",
gia: ""
}`

Nesse PR estou apenas mudando o tipo de `Int32` para `Int32?`, nesse caso ele terá o valor nulo caso venha uma string vazia.

Se precisar de mais exemplos, tenho outros CEPs que estão com esse problema.

Valeu 👍 