### PR TITLE
[CHORE] Bump target frameworks to net 10 and update build configuration +semver: major

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,30 +2,111 @@ version: 2
 
 updates:
 
-- package-ecosystem: "nuget"
-  directory: "/"
-  schedule:
-    interval: weekly
-  open-pull-requests-limit: 50
-  assignees:
-    - "guibranco"
-  reviewers:
-    - "guibranco"
-  labels:
-    - "nuget"
-    - "packages"
-    - ".NET"
-    - "dependencies"
+  #
+  # NuGet dependencies
+  #
+  - package-ecosystem: "nuget"
+    directory: "/"
+    schedule:
+      interval: weekly
 
-- package-ecosystem: "github-actions"
-  directory: "/"
-  schedule:
-    interval: weekly
-  open-pull-requests-limit: 50
-  assignees:
-    - "guibranco"
-  reviewers:
-    - "guibranco"
-  labels:
-    - "github-actions"
-    - "dependencies"
+    open-pull-requests-limit: 10
+
+    assignees:
+      - "guibranco"
+
+    reviewers:
+      - "guibranco"
+
+    labels:
+      - "nuget"
+      - "packages"
+      - ".NET"
+      - "dependencies"
+
+    groups:
+
+      #
+      # Microsoft packages
+      #
+      microsoft:
+        patterns:
+          - "Microsoft.*"
+
+      #
+      # ASP.NET Core stack
+      #
+      aspnetcore:
+        patterns:
+          - "Microsoft.AspNetCore.*"
+
+      #
+      # Extensions ecosystem
+      #
+      extensions:
+        patterns:
+          - "Microsoft.Extensions.*"
+
+      #
+      # Test stack
+      #
+      testing:
+        patterns:
+          - "xunit*"
+          - "FluentAssertions*"
+          - "Moq*"
+          - "coverlet*"
+          - "Microsoft.NET.Test.Sdk"
+
+      #
+      # Logging stack
+      #
+      logging:
+        patterns:
+          - "Serilog*"
+          - "NLog*"
+
+      #
+      # OpenTelemetry
+      #
+      telemetry:
+        patterns:
+          - "OpenTelemetry*"
+
+      #
+      # Azure SDK
+      #
+      azure:
+        patterns:
+          - "Azure.*"
+
+      #
+      # Everything else
+      #
+      dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+
+    schedule:
+      interval: weekly
+
+    open-pull-requests-limit: 5
+
+    assignees:
+      - "guibranco"
+
+    reviewers:
+      - "guibranco"
+
+    labels:
+      - "github-actions"
+      - "dependencies"
+
+    groups:
+
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,11 +23,9 @@ jobs:
           distribution: temurin
 
       - name: 🧰 Setup .NET SDK
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: |
-            8.0.x
-            10.0.x
+          dotnet-version: '10.0.x'
 
       - name: 🔧 Install SonarCloud scanner
         run: dotnet tool install --global dotnet-sonarscanner

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,8 +26,8 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
-            6.0.x
             8.0.x
+            10.0.x
 
       - name: 🔧 Install SonarCloud scanner
         run: dotnet tool install --global dotnet-sonarscanner

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,9 +34,9 @@ jobs:
           echo "${{ toJson(steps.gitversion.outputs) }}"
 
       - name: 🧰 Setup .NET SDK
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: '10.0.x'
 
       - name: 📦 Restore dependencies
         run: dotnet restore

--- a/.github/workflows/size-label.yml
+++ b/.github/workflows/size-label.yml
@@ -2,7 +2,6 @@ name: Label based on PR size
 
 on:
   pull_request:
-  pull_request_target:
   workflow_dispatch:
 
 jobs:
@@ -17,9 +16,6 @@ jobs:
           (
             github.event_name == 'pull_request' &&
             github.event.pull_request.head.repo.full_name == github.repository
-          ) || (
-            github.event_name == 'pull_request_target' &&
-            github.event.pull_request.head.repo.full_name != github.repository
           ) || (
             github.event_name == 'workflow_dispatch'
           )

--- a/Src/ViaCep/ViaCep.csproj
+++ b/Src/ViaCep/ViaCep.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <ProjectGuid>A251D320-410E-48F1-889D-9F59EB8CFEB9</ProjectGuid>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net8.0;net10.0</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <LangVersion>latest</LangVersion>
     <Company>Guilherme Branco Stracini</Company>

--- a/Tests/ViaCep.IntegrationTests/ViaCep.IntegrationTests.csproj
+++ b/Tests/ViaCep.IntegrationTests/ViaCep.IntegrationTests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/Tests/ViaCep.Tests/ViaCep.Tests.csproj
+++ b/Tests/ViaCep.Tests/ViaCep.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <ProjectGuid>2F57B9CD-5505-4456-B9FE-F91DCB4476D6</ProjectGuid>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
## 📑 Description
Bump target frameworks to net 10 and update build configuration +semver: major

## ✅ Checks
- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ☢️ Does this introduce a breaking change?
- [X] Yes
- [ ] No

---

## Summary by Sourcery

Update project and infrastructure to target .NET 10 and refresh dependency and CI configuration.

Build:
- Retarget ViaCep library and test projects to .NET 10.
- Adjust Dependabot configuration with grouped NuGet and GitHub Actions updates and lower concurrent PR limits.
- Update GitHub Actions workflows to use actions/setup-dotnet v5 with .NET 10 SDK and simplify the PR size labeling trigger conditions.

CI:
- Refresh build and deploy workflows to run solely on .NET 10 using the latest setup-dotnet action.
- Simplify the size-label workflow triggers by removing pull_request_target handling.

Chores:
- Restructure Dependabot settings to group related dependencies (Microsoft, ASP.NET Core, testing, logging, telemetry, Azure, and others) for more organized update PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded build and test pipelines to target .NET 10.0, removing support for .NET 6.0.
  * Enhanced GitHub Actions workflow configuration with updated tooling versions.
  * Improved dependency management strategy by organizing and limiting concurrent dependency updates across ecosystems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->